### PR TITLE
Fix paginator examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ I uploaded this for the demonstration of slash command.
 This simple example shows how to easily create interactive, multiple page embeds that annyone can interact with.
 ### Paginator Installation
 
-> pip install dinteractions-Paginator
+```
+pip install dinteractions-Paginator
+```
 
 ### Paginator Example
 
@@ -41,6 +43,7 @@ bot.run("token")
 > discord.py >= 1.5.1  
 > discord-py-slash-command >= 1.1.0 
 > aiosqlite
+> dinteractions-Paginator
 
 ## Any questions?
 Visit [discord-py-slash-command Discord Server](https://discord.gg/KkgMBVuEkx).

--- a/cogs/paginator.py
+++ b/cogs/paginator.py
@@ -88,7 +88,7 @@ class paginator(commands.Cog):
         p6.add_field(name="Example", value=f"{example2}")
         pages = [p1, p2, p3, p4, p5, p6]
         await Paginator(
-            bot=self.bot, ctx=ctx, pages=pages, content="Paginator example"
+            bot=self.bot, ctx=ctx, pages=pages, content="Paginator example", timeout=60
         )
 
 

--- a/cogs/paginator.py
+++ b/cogs/paginator.py
@@ -10,16 +10,16 @@ example1 = """\
 import discord
 import discord_slash
 from discord_slash import SlashCommand, SlashContext
-from Paginator import Paginator
+from dinteractions_Paginator import Paginator
 
 
 @slash.slash(name="command")
-async def command(ctx:SlashContext)
-    embed1=discord.Embed(title="title")
-    embed2=discord.Embed(title="another title")
-    embed3=discord.Embed(title="yet another title")
-    pages=[embed1,embed2,embed3]
-    await Paginator(bot=bot,ctx=ctx,pages=pages)
+async def command(ctx: SlashContext):
+    embed1 = discord.Embed(title="title")
+    embed2 = discord.Embed(title="another title")
+    embed3 = discord.Embed(title="yet another title")
+    pages = [embed1, embed2, embed3]
+    await Paginator(bot=bot, ctx=ctx, pages=pages)
     
 
 ```
@@ -29,18 +29,22 @@ example2 = """\
 import discord
 import discord_slash
 from discord_slash import SlashCommand, SlashContext
-from Paginator import Paginator
+from dinteractions_Paginator import Paginator
 
 
 @slash.slash(name="command")
-    async def command(ctx:SlashContext)
-    embed1=discord.Embed(title="title")
-    embed2=discord.Embed(title="another title")
-    embed3=discord.Embed(title="yet another title")
-    pages=[embed1,embed2,embed3]
+    async def command(ctx: SlashContext):
+    embed1 = discord.Embed(title="Title")
+    embed2 = discord.Embed(title="Another Title")
+    embed3 = discord.Embed(title="Yet Another Title")
+    pages = [embed1, embed2, embed3]
 
-    await Paginator(bot=bot,ctx=ctx,pages=pages,content="Hello there",prevLabel="Back",nextLabel="Forward",
-            prevEmoji="♥",nextEmoji="♥",prevStyle=1,nextStyle=2,indexStyle=3,timeout=10)
+    await Paginator(bot=bot, ctx=ctx,
+        pages=pages, content="Hello there",
+        prevLabel="Back", nextLabel="Forward",
+        prevEmoji="♥", nextEmoji="♥",
+        prevStyle=1, nextStyle=2, 
+        indexStyle=3, timeout=10)
 
 ```
 """
@@ -58,33 +62,33 @@ class paginator(commands.Cog):
     async def paginator(self, ctx):
         p1 = discord.Embed(
             title="This is an example embed",
-            description="This module allows to have infinitetly long multi page embeds",
+            description="This module allows to have infinitetly long multi-page embeds, more information [here](https://pypi.org/project/dinteractions-Paginator/)",
         )
         p2 = discord.Embed(
-            title="It's higly customizable",
-            description="It allows you to modify all aspects of the paginator, from the title on the buttons, a persistent message, all the way to a timeout",
+            title="It's highly customizable",
+            description="It allows you to modify all aspects of the paginator, from the title on the buttons, a persistent message, all the way to a timeout!",
         )
         p3 = discord.Embed(
             title="Easy to implement",
-            description="All you need to do is [download the file](https://github.com/JUGADOR123/Paginator.py), import it and you are ready to rock",
+            description="All you need to do is install the library (`pip install dinteractions-Paginator`), import it, and you are ready to rock!",
         )
         p4 = discord.Embed(
             title="Simple Example",
-            description="The simplest way of implementing it only requires a list of the embeds to be added as pages",
+            description="The simplest way of implementing it only requires a list of the embeds to be added as pages!",
         )
         p4.add_field(name="Example", value=f"{example1}")
         p5 = discord.Embed(
             title="Customized Example",
-            description="You can change all aspects of the paginator by declaring them when calling the funtion",
+            description="You can change all aspects of the paginator by declaring them when calling the function.",
         )
         p6 = discord.Embed(
             title="In depth example",
-            description="Here we can see an example that customizes all the aspects of the paginator, and includes a persistent message",
+            description="This is an example that customizes all the aspects of the paginator, and includes a persistent message!",
         )
         p6.add_field(name="Example", value=f"{example2}")
         pages = [p1, p2, p3, p4, p5, p6]
         await Paginator(
-            bot=self.bot, ctx=ctx, pages=pages, content="Paginator example", timeout=60
+            bot=self.bot, ctx=ctx, pages=pages, content="Paginator example"
         )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ discord-py-slash-command >= 1.1.0
 aiosqlite
 fuzzywuzzy[speedup]
 PyGithub
+dinteractions-Paginator


### PR DESCRIPTION
This PR fixes the typos in the paginator examples, and follows PEP 8 (I think).
It also adds it as a requirement in requirements.txt and README.md.
